### PR TITLE
Include single pages

### DIFF
--- a/Controller/PresentationController.php
+++ b/Controller/PresentationController.php
@@ -43,7 +43,7 @@ class PresentationController extends Controller
     /**
      * @ApiDoc(
      *  resource=true,
-     *  description="EMO text API item resource",
+     *  description="EMO text API item page resource",
      *  requirements={
      *      {"name"="id", "dataType"="string", "required"=true, "description"="work identifier"}
      *  }
@@ -54,6 +54,39 @@ class PresentationController extends Controller
         $document = $this->translator->getDocumentById($id);
 
         return $this->view($this->presentationService->getItem($document), Response::HTTP_OK);
+    }
+
+    /**
+     * @ApiDoc(
+     *  resource=true,
+     *  description="EMO text API item full resource",
+     *  requirements={
+     *      {"name"="id", "dataType"="string", "required"=true, "description"="work identifier"}
+     *  }
+     * )
+     */
+    public function fullAction(string $id): View
+    {
+        $document = $this->translator->getDocumentById($id);
+
+        return $this->view($this->presentationService->getFull($document), Response::HTTP_OK);
+    }
+
+
+    /**
+     * @ApiDoc(
+     *  resource=true,
+     *  description="EMO text API full content resource",
+     *  requirements={
+     *      {"name"="id", "dataType"="string", "required"=true, "description"="work identifier"}
+     *  }
+     * )
+     */
+    public function contentAction(string $id): View
+    {
+        $document = $this->translator->getDocumentById($id);
+
+        return $this->view($this->presentationService->getContent($document), Response::HTTP_OK);
     }
 
     /**

--- a/Model/Document.php
+++ b/Model/Document.php
@@ -75,19 +75,19 @@ class Document implements DocumentInterface
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getTitle(): string
+    public function getTitle(): ?string
     {
         return $this->title;
     }
 
     /**
-     * @param string $title
+     * @param string|null $title
      *
      * @return DocumentInterface
      */
-    public function setTitle(string $title): DocumentInterface
+    public function setTitle(?string $title): DocumentInterface
     {
         $this->title = $title;
 
@@ -123,11 +123,11 @@ class Document implements DocumentInterface
     }
 
     /**
-     * @param string $author
+     * @param string|null $author
      *
      * @return DocumentInterface
      */
-    public function setAuthor(string $author): DocumentInterface
+    public function setAuthor(?string $author): DocumentInterface
     {
         $this->author = $author;
 
@@ -143,11 +143,11 @@ class Document implements DocumentInterface
     }
 
     /**
-     * @param string $recipient
+     * @param string|null $recipient
      *
      * @return DocumentInterface
      */
-    public function setRecipient(string $recipient): DocumentInterface
+    public function setRecipient(?string $recipient): DocumentInterface
     {
         $this->recipient = $recipient;
 
@@ -163,11 +163,11 @@ class Document implements DocumentInterface
     }
 
     /**
-     * @param string $originPlace
+     * @param string|null $originPlace
      *
      * @return DocumentInterface
      */
-    public function setOriginPlace(string $originPlace): DocumentInterface
+    public function setOriginPlace(?string $originPlace): DocumentInterface
     {
         $this->originPlace = $originPlace;
 
@@ -183,11 +183,11 @@ class Document implements DocumentInterface
     }
 
     /**
-     * @param string $destinationPlace
+     * @param string|null $destinationPlace
      *
      * @return DocumentInterface
      */
-    public function setDestinationPlace(string $destinationPlace): DocumentInterface
+    public function setDestinationPlace(?string $destinationPlace): DocumentInterface
     {
         $this->destinationPlace = $destinationPlace;
 
@@ -203,11 +203,11 @@ class Document implements DocumentInterface
     }
 
     /**
-     * @param string $originDate
+     * @param string|null $originDate
      *
      * @return DocumentInterface
      */
-    public function setOriginDate(string $originDate): DocumentInterface
+    public function setOriginDate(?string $originDate): DocumentInterface
     {
         $this->originDate = $originDate;
 

--- a/Model/DocumentInterface.php
+++ b/Model/DocumentInterface.php
@@ -8,16 +8,16 @@ namespace Subugoe\EMOBundle\Model;
 interface DocumentInterface
 {
     /**
-     * @return string
+     * @return string|null
      */
-    public function getTitle(): string;
+    public function getTitle(): ?string;
 
     /**
-     * @param string $title
+     * @param string|null $title
      *
      * @return DocumentInterface
      */
-    public function setTitle(string $title): DocumentInterface;
+    public function setTitle(?string $title): DocumentInterface;
 
     /**
      * @return string
@@ -37,11 +37,11 @@ interface DocumentInterface
     public function getAuthor(): string;
 
     /**
-     * @param string $author
+     * @param string|null $author
      *
      * @return DocumentInterface
      */
-    public function setAuthor(string $author): DocumentInterface;
+    public function setAuthor(?string $author): DocumentInterface;
 
     /**
      * @return string
@@ -49,11 +49,11 @@ interface DocumentInterface
     public function getRecipient(): string;
 
     /**
-     * @param string $recipient
+     * @param string|null $recipient
      *
      * @return DocumentInterface
      */
-    public function setRecipient(string $recipient): DocumentInterface;
+    public function setRecipient(?string $recipient): DocumentInterface;
     
     /**
      * @return string
@@ -61,11 +61,11 @@ interface DocumentInterface
     public function getOriginPlace(): string;
 
     /**
-     * @param string $originPlace
+     * @param string|null $originPlace
      *
      * @return DocumentInterface
      */
-    public function setOriginPlace(string $originPlace): DocumentInterface;
+    public function setOriginPlace(?string $originPlace): DocumentInterface;
 
     /**
      * @return string
@@ -73,11 +73,11 @@ interface DocumentInterface
     public function getDestinationPlace(): string;
 
     /**
-     * @param string $destinationPlace
+     * @param string|null $destinationPlace
      *
      * @return DocumentInterface
      */
-    public function setDestinationPlace(string $destinationPlace): DocumentInterface;
+    public function setDestinationPlace(?string $destinationPlace): DocumentInterface;
 
     /**
      * @return string
@@ -85,9 +85,9 @@ interface DocumentInterface
     public function getOriginDate(): string;
 
     /**
-     * @param string $originDate
+     * @param string|null $originDate
      *
      * @return DocumentInterface
      */
-    public function setOriginDate(string $originDate): DocumentInterface;
+    public function setOriginDate(?string $originDate): DocumentInterface;
 }

--- a/Model/Presentation/Content.php
+++ b/Model/Presentation/Content.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Subugoe\EMOBundle\Model\Presentation;
+
+/**
+ * Item content
+ *
+ * @see https://subugoe.pages.gwdg.de/emo/text-api/page/specs/#item-object
+ */
+class Content
+{
+    /**
+     * @var string
+     */
+    private $content;
+
+    /**
+     * @return string
+     */
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    /**
+     * @param string $content
+     *
+     * @return Content
+     */
+    public function setContent(string $content): self
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+}

--- a/Model/Presentation/Item.php
+++ b/Model/Presentation/Item.php
@@ -24,7 +24,7 @@ class Item
     /**
      * @var string
      */
-    private $type = 'full';
+    private $type;
 
     /**
      * @var array

--- a/Model/Presentation/Title.php
+++ b/Model/Presentation/Title.php
@@ -20,7 +20,7 @@ class Title
     /**
      * @var string
      */
-    private $type = 'main';
+    private $type;
 
     /**
      * @return string
@@ -31,11 +31,11 @@ class Title
     }
 
     /**
-     * @param string $title
+     * @param string|null $title
      *
      * @return Title
      */
-    public function setTitle(string $title): self
+    public function setTitle(?string $title): self
     {
         $this->title = $title;
 

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,9 +1,20 @@
-subugoe_emo_item:
-    path:      "gfl/{id}/latest/item.json"
+subugoe_emo_item_page:
+    path:      "gfl/{id}/{revision}/item.json"
     methods:  "GET"
-    defaults: { _controller: SubugoeEMOBundle:Presentation:item }
+    defaults: { _controller: SubugoeEMOBundle:Presentation:item, "revision":"latest" }
+
+subugoe_emo_item_full:
+    path:      "gfl/{id}/{revision}/full.json"
+    methods:  "GET"
+    defaults: { _controller: SubugoeEMOBundle:Presentation:full, "revision":"0.0.2" }
+
 subugoe_emo_manifest:
     path:      "gfl/{id}/manifest.json"
     methods:  "GET"
     defaults: { _controller: SubugoeEMOBundle:Presentation:manifest }
+
+subugoe_emo_content:
+    path:      "gfl/{id}/content"
+    methods:  "GET"
+    defaults: { _controller: SubugoeEMOBundle:Presentation:content }
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -7,7 +7,7 @@ services:
 
   subugoe_emo.presentation_service:
     class:      Subugoe\EMOBundle\Service\PresentationService
-    arguments:  ["@router", "@translator", "@request_stack", "@assets.packages"]
+    arguments:  ["@router", "@translator", "@request_stack", "@assets.packages", "@subugoe_emo.translator"]
 
   subugoe_emo.translator:
     class:      Subugoe\EMOBundle\Translator\SubugoeTranslator

--- a/Translator/SubugoeTranslator.php
+++ b/Translator/SubugoeTranslator.php
@@ -39,13 +39,13 @@ class SubugoeTranslator implements TranslatorInterface
 
         $document
             ->setId($solrDocument['id'])
-            ->setTitle($solrDocument['title'])
-            ->setContent($solrDocument['fulltext_html'])
-            ->setAuthor($solrDocument['author'])
-            ->setRecipient($solrDocument['recipient'])
-            ->setOriginPlace($solrDocument['origin_place'])
-            ->setDestinationPlace($solrDocument['destination_place'])
-            ->setOriginDate(date("d.m.Y", strtotime($solrDocument['origin_date'])));
+            ->setTitle($solrDocument['title'] ?? null)
+            ->setContent($solrDocument['fulltext_html'] ?? $solrDocument['html_page'])
+            ->setAuthor($solrDocument['author'] ?? null)
+            ->setRecipient($solrDocument['recipient'] ?? null)
+            ->setOriginPlace($solrDocument['origin_place'] ?? null)
+            ->setDestinationPlace($solrDocument['destination_place'] ?? null)
+            ->setOriginDate(!empty($solrDocument['origin_date']) ? date("d.m.Y", strtotime($solrDocument['origin_date'])) : null);
 
         return $document;
     }
@@ -69,5 +69,24 @@ class SubugoeTranslator implements TranslatorInterface
         $solrDocument = $select->getDocuments()[0];
 
         return $solrDocument;
+    }
+
+    /**
+     * @param string $id
+     *
+     * @return array
+     */
+    public function getContentsById(string $id): array
+    {
+        $query = $this->client->createSelect()
+            ->setQuery(sprintf('article_id:%s', $id));
+        $select = $this->client->select($query);
+        $count = $select->count();
+
+        if (0 === $count) {
+            throw new \InvalidArgumentException(sprintf('No contents found for the Document %s', $id));
+        }
+
+        return $select->getDocuments();
     }
 }

--- a/Translator/TranslatorInterface.php
+++ b/Translator/TranslatorInterface.php
@@ -14,4 +14,6 @@ interface TranslatorInterface
      * @return DocumentInterface
      */
     public function getDocumentById(string $id): DocumentInterface;
+
+    public function getContentsById(string $id): array ;
 }


### PR DESCRIPTION
This includes document's single pages as well as the full version
in the manifest and outsources the content under its own page and url.
Document's missing css classes also included.

Resolves EMO-41, EMO-44 and EMO-46