### PR TITLE
Return sorted annotation items

### DIFF
--- a/src/Model/Document.php
+++ b/src/Model/Document.php
@@ -52,6 +52,8 @@ class Document implements DocumentInterface
     private ?array $pageNotes = null;
 
     private ?array $pageNotesIds = null;
+    
+    private ?array $pageAllAnnotationIds = null;
 
     private ?string $pageNumber = null;
 
@@ -209,6 +211,11 @@ class Document implements DocumentInterface
     public function getPageSicsIds(): ?array
     {
         return $this->pageSicsIds;
+    }
+
+    public function getPageAllAnnotationIds(): ?array
+    {
+        return $this->pageAllAnnotationIds;
     }
 
     public function getPublishDate(): ?string
@@ -440,6 +447,13 @@ class Document implements DocumentInterface
     {
         $this->pageSicsIds = $pageSicsIds;
 
+        return $this;
+    }
+    
+    public function setPageAllAnnotationIds(?array $pageAllAnnotationIds): DocumentInterface
+    {
+        $this->pageAllAnnotationIds = $pageAllAnnotationIds;
+        
         return $this;
     }
 

--- a/src/Model/DocumentInterface.php
+++ b/src/Model/DocumentInterface.php
@@ -55,6 +55,8 @@ interface DocumentInterface
 
     public function getPageSicsIds(): ?array;
 
+    public function getPageAllAnnotationIds(): ?array;
+
     public function getPublishDate(): ?string;
 
     public function getRecipient(): ?string;
@@ -120,6 +122,8 @@ interface DocumentInterface
     public function setPageSegs(?array $pageSegs): DocumentInterface;
 
     public function setPageSicsIds(?array $pageNotesIds): DocumentInterface;
+
+    public function setPageAllAnnotationIds(?array $pageAllAnnotationIds): DocumentInterface;
 
     public function setPublishDate(?string $originDate): DocumentInterface;
 

--- a/src/Translator/SubugoeTranslator.php
+++ b/src/Translator/SubugoeTranslator.php
@@ -105,6 +105,10 @@ class SubugoeTranslator implements TranslatorInterface
             $document->setPageDatesIds($solrDocument['page_dates_ids']);
         }
 
+        if (isset($solrDocument['page_all_annotation_ids']) && !empty($solrDocument['page_all_annotation_ids'])) {
+            $document->setPageAllAnnotationIds($solrDocument['page_all_annotation_ids']);
+        }
+
         $document
             ->setLicense($solrDocument['license'])
             ->setLanguage($solrDocument['language'])


### PR DESCRIPTION
We need to return annotation items in a sorted way. First they should be sorted in order of appearance in the text. Since all different types of annotations are distributed among different Solr fields, we need to create a separate list of all annotation ids which serves as ordered list. This is the `page_all_annotation_ids`field. During assembling of annotation items we return a sorted array by that field.